### PR TITLE
Mark student view for multi_device (mobile ready)

### DIFF
--- a/done/done.py
+++ b/done/done.py
@@ -83,6 +83,7 @@ class DoneXBlock(XBlock, CompletableXBlockMixin):
 
         return {'state': self.done}
 
+    @XBlock.supports("multi_device")
     def student_view(self, context=None):  # pylint: disable=unused-argument
         """
         The primary view of the DoneXBlock, shown to students


### PR DESCRIPTION
This works fine on mobile in web view and native app, so marking with `supports("multi_device")` decorator.

# TODOs
 - [x] Let's wait for #10 to get merged as the layout have been changed

Then let's rebase and I'll do a full test on this PR on:
   * [x] Mobile web - staff
   * [x] Mobile web - student 
   * [x] Mobile app / Android
   * [x] Mobile app / iOS (but I don't have OS)

# Browsers
## Android, Samsung Galaxy S9 (in Chrome app)
<img width="370" alt="screen shot 2018-09-03 at 12 56 03 pm" src="https://user-images.githubusercontent.com/1289191/45598205-423a6d80-b9d8-11e8-827a-cc7d6f02159d.png">


## iPhone X (in Safari app)
<img width="380" alt="screen shot 2018-09-03 at 12 58 11 pm" src="https://user-images.githubusercontent.com/1289191/45598208-52eae380-b9d8-11e8-8e13-06921377eff3.png">


# Native Apps

## Android
![screenshot_20180814-121832](https://user-images.githubusercontent.com/1289191/44113577-6814a082-9fbd-11e8-986a-d3ded26492c3.png)
![screenshot_20180814-121837](https://user-images.githubusercontent.com/1289191/44113588-6f679f06-9fbd-11e8-9314-beb835410e0e.png)

## iOS
![img_ece9c09495b2-1](https://user-images.githubusercontent.com/1289191/44165911-d7b3ac00-a07e-11e8-9d69-d01ea456bdd5.jpeg)
