### PR TITLE
Integrate with the new Open edX completion API

### DIFF
--- a/done/done.py
+++ b/done/done.py
@@ -6,6 +6,14 @@ import uuid
 from xblock.core import XBlock
 from xblock.fields import Scope, String, Boolean, DateTime, Float
 from xblock.fragment import Fragment
+try: 
+    from xblock.completable import CompletableXBlockMixin
+except ImportError:
+    class CompletableXBlockMixin:
+        """ No-op mixin for pre-Hawthorn Open edX versions """
+        def emit_completion(self, completion_percent):
+            pass
+
 
 def resource_string(path):
     """Handy helper for getting resources from our kit."""
@@ -13,7 +21,7 @@ def resource_string(path):
     return data.decode("utf8")
 
 
-class DoneXBlock(XBlock):
+class DoneXBlock(XBlock, CompletableXBlockMixin):
     """
     Show a toggle which lets students mark things as done.
     """
@@ -51,6 +59,7 @@ class DoneXBlock(XBlock):
             # This should move to self.runtime.publish, once that pipeline
             # is finished for XBlocks.
             self.runtime.publish(self, "edx.done.toggled", {'done': self.done})
+            self.emit_completion(grade)
 
         return {'state': self.done}
 

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ def package_data(pkg, root):
 
 setup(
     name='done-xblock',
-    version='0.1',
-    description='done XBlock',   # TODO: write a better description.
+    version='0.2',
+    description="An XBlock for students to mark they've done something",
     packages=[
         'done',
     ],


### PR DESCRIPTION
This is a simple modification of Done XBlock so that it integrates with the completion framework introduced in Open edX Hawthorn.

The "green check" shown above the course content will now properly reflect the completion status of any Done XBlocks on the page.

![green check](https://user-images.githubusercontent.com/945577/45244631-8083ae80-b2ad-11e8-85b3-b27b60c69621.png)

Test instructions:

1. Check out this branch on a Hawthorn or newer devstack and restart the LMS
1. In the LMS console run `./manage.py lms waffle_switch completion.enable_completion_tracking on --create --settings=devstack_docker` to enable the completion tracking
1. Create a unit with only this block
1. Mark the block as complete and refresh the page. The green check should appear.
1. Mark the block as not complete and refresh the page. The green check should be gone.

Compatibility: Includes code to make this backwards compatible with pre-Hawthorn Open edX versions